### PR TITLE
Reverted PyQt5-Qt5 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ pycparser==2.22
 Pygments==2.17.2
 pyparsing==3.1.2
 PyQt5==5.15.11
-PyQt5-Qt5==5.15.16
+PyQt5-Qt5==5.15.2
 PyQt5_sip==12.15.0
 python-dateutil==2.9.0.post0
 python-json-logger==2.0.7


### PR DESCRIPTION
v5.15.10+ does not appear to be supported on Windows systems